### PR TITLE
Add change password functionality on backend

### DIFF
--- a/user-service/src/model/repository.ts
+++ b/user-service/src/model/repository.ts
@@ -28,6 +28,19 @@ export async function deleteUser(username: string) {
     });
 }
 
+export async function updateUserPassword(username: string, password: string) {
+  await UserModel.findOneAndUpdate(
+    { username: username },
+    { password: password }
+  )
+    .then(() => {
+      console.log("user password updated!");
+    })
+    .catch((Error) => {
+      return Error;
+    });
+}
+
 export async function isUsernameExist(username: string) {
   // return 1 if username exists else 0
   return UserModel.find({ username }, "_id").count();

--- a/user-service/src/model/user-orm.ts
+++ b/user-service/src/model/user-orm.ts
@@ -2,6 +2,7 @@ import {
   createUser,
   deleteUser,
   getId,
+  updateUserPassword,
   isUsernameAndPasswordMatch,
   isUsernameExist,
 } from "./repository";
@@ -25,6 +26,19 @@ export async function ormDeleteUser(username: string) {
     return true;
   } catch (err) {
     console.log("ERROR: Could not delete user");
+    return false;
+  }
+}
+
+export async function ormUpdateUserPassword(
+  username: string,
+  password: string
+) {
+  try {
+    await updateUserPassword(username, password);
+    return true;
+  } catch (err) {
+    console.log("ERROR: Could not update user password");
     return false;
   }
 }


### PR DESCRIPTION
## Status

READY

## Description

The application does not support change password functionality on the backend. Let's do the following to allow users to change password:
* Create a post request in user controller
* Create a change user password function in user-orm and repository to mutate the mongodb document
* Handle checked errors for same password, no jwt, invalid jwt, mismatch of password and username
* Create new jwt on succesful update of password

Closes #16 
## Screenshots

A few screenshots displaying the changes made by the pull request.

## Todos

* [X] Have you cleaned up your code? (Eg. remove redundant code/comments, fix warnings, refactor duplicate code etc.)
* [X] Have you manually tested your code extensively? (Eg. execute the happy path, try out edge cases etc.)
* [X] Have you linked your PR to the respective issues?
* [ ] Have you generated documentation for your changes?
